### PR TITLE
Determine Git commit author from token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,7 @@ runs:
         cache: enable
     - id: commit-author
       name: Determine Git user info from GitHub token
+      shell: bash
       run: |
         VIEWER_JSON=$(gh api graphql -f query='query { viewer { name login databaseId }}' --jq '.data.viewer')
         VIEWER_NAME=$(jq --raw-output '.name | values' <<< "${VIEWER_JSON}")
@@ -48,7 +49,9 @@ runs:
         echo "name=${USER_NAME}" >> "${GITHUB_OUTPUT}"
         echo "email=${USER_EMAIL}" >> "${GITHUB_OUTPUT}"
       # env GITHUB_TOKEN from action
-    - run: |
+    - name: Run release-plz
+      shell: bash
+      run: |
         if [ -z "${CARGO_REGISTRY_TOKEN-unset}" ]
         then
             echo "\$CARGO_REGISTRY_TOKEN environment variable is set to empty string. Please set your token in GitHub actions secrets. Docs: https://marcoieni.github.io/release-plz/github/index.html"
@@ -91,4 +94,3 @@ runs:
             ${ALT_REGISTRY}\
             ${PROJECT_MANIFEST}
         fi
-      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,20 @@ runs:
         repo: MarcoIeni/release-plz
         tag: ${{ inputs.version }}
         cache: enable
+    - id: commit-author
+      name: Determine Git user info from GitHub token
+      run: |
+        VIEWER_JSON=$(gh api graphql -f query='query { viewer { name login databaseId }}' --jq '.data.viewer')
+        VIEWER_NAME=$(jq --raw-output '.name | values' <<< "${VIEWER_JSON}")
+        VIEWER_LOGIN=$(jq --raw-output '.login' <<< "${VIEWER_JSON}")
+        VIEWER_DATABASE_ID=$(jq --raw-output '.databaseId' <<< "${VIEWER_JSON}")
+
+        USER_NAME="${VIEWER_NAME:-${VIEWER_LOGIN}}"
+        USER_EMAIL="${VIEWER_DATABASE_ID}+${VIEWER_LOGIN}@users.noreply.github.com"
+
+        echo "name=${USER_NAME}" >> "${GITHUB_OUTPUT}"
+        echo "email=${USER_EMAIL}" >> "${GITHUB_OUTPUT}"
+      # env GITHUB_TOKEN from action
     - run: |
         if [ -z "${CARGO_REGISTRY_TOKEN-unset}" ]
         then
@@ -56,8 +70,8 @@ runs:
             PROJECT_MANIFEST=""
         fi
 
-        git config --global user.email "release-plz@github.com"
-        git config --global user.name "release-plz"
+        git config --global user.email "${{ steps.commit-author.outputs.email }}"
+        git config --global user.name "${{ steps.commit-author.outputs.name }}"
 
         if [[ -z "${{ inputs.command }}" || "${{ inputs.command }}" == "release-pr" ]]
         then

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ runs:
       name: Determine Git user info from GitHub token
       shell: bash
       run: |
+        # The environment variable GITHUB_TOKEN is read by the `gh` cli
         VIEWER_JSON=$(gh api graphql -f query='query { viewer { name login databaseId }}' --jq '.data.viewer')
         VIEWER_NAME=$(jq --raw-output '.name | values' <<< "${VIEWER_JSON}")
         VIEWER_LOGIN=$(jq --raw-output '.login' <<< "${VIEWER_JSON}")
@@ -48,7 +49,6 @@ runs:
 
         echo "name=${USER_NAME}" >> "${GITHUB_OUTPUT}"
         echo "email=${USER_EMAIL}" >> "${GITHUB_OUTPUT}"
-      # env GITHUB_TOKEN from action
     - name: Run release-plz
       shell: bash
       run: |


### PR DESCRIPTION
For https://github.com/MarcoIeni/release-plz/issues/999

Determine Git `user.name` and `user.email` from the GitHub token.

# Examples

Default token:
```
name: github-actions[bot]
email: 41898282+github-actions[bot]@users.noreply.github.com
```

Personal Access Token (@robo9k):
Note that this doesn _not_ leak the user email, even if they have one set to publically visible on their profile https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#setting-your-commit-email-address-on-github
https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-user-account-settings/changing-your-github-username#your-git-commits
```
name: robot9001
email: 1538025+robo9k@users.noreply.github.com
```

GitHub App (`arbeitsmaschine`):
```
name: arbeitsmaschine[bot]
email: 146221907+arbeitsmaschine[bot]@users.noreply.github.com
```

Note that the previously hardcoded `release-plz <release-plz@github.com>` will NOT be used anymore.