### PR TITLE
feat: add support for specifying backend

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   config:
     description: "Config file location. If not present, the default 'release-plz.toml' is used."
     required: false
+  backend:
+    description: "Forge backend. Valid values: 'github', 'gitea'"
+    default: "github"
+    required: false
   manifest_path:
     description:
       "Path to the Cargo.toml of the project you want to update. If not provided, release-plz will use the Cargo.toml of the
@@ -76,6 +80,14 @@ runs:
             TOKEN=""
         fi
 
+        if [[ -n "${{ inputs.backend }}" ]]
+        then
+          echo "using backend '${{ inputs.backend }}'"
+          BACKEND="--backend ${{ inputs.backend }}"
+        else
+          BACKEND=""
+        fi
+
         if [[ -n "${{ inputs.registry }}" ]]
         then
             echo "using registry '${{ inputs.registry }}'"
@@ -105,6 +117,7 @@ runs:
                 ${CONFIG_PATH}\
                 ${ALT_REGISTRY}\
                 ${MANIFEST_PATH}\
+                ${BACKEND}\
                 -o json)
             echo "release_pr_output: $release_pr_output"
             prs=$(echo $release_pr_output | jq -c .prs)
@@ -129,6 +142,7 @@ runs:
                 ${CONFIG_PATH}\
                 ${ALT_REGISTRY}\
                 ${MANIFEST_PATH}\
+                ${BACKEND}\
                 ${TOKEN}\
                 -o json)
             echo "release_output: $release_output"


### PR DESCRIPTION
This PR exposes the `backend` option to allow use with non-github repos. e.g. ForgeJo which is Gitea compatible (for now) and can use Github Actions in it's CI.