### PR TITLE
Do not lose release-plz output on 422

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -178,7 +178,7 @@ runs:
                 # GitHub can return 422 for no-op/unprocessable release-pr calls.
                 # Treat this as "nothing to create" instead of failing the whole action.
                 if [[ "$release_pr_error" == *"422"* ]]; then
-                    echo "::warning::release-plz release-pr failed with HTTP 422; continuing with no PRs created."
+                    echo "::warning::release-plz release-pr failed with HTTP 422; continuing with no PRs created.\n$release_pr_error"
                     release_pr_output='{"prs":[]}'
                 else
                     echo "$release_pr_error" >&2


### PR DESCRIPTION
HTTP 422 can trigger for a very wide number of reasons, and debugging those reasons is difficult if the error output is suppressed.

For instance on ua-parser/uap-rust#63 I first tested the workflow on my fork and everything was fine (masklinn/uap-rust#2), but it immediately failed when it was merged, and [the only feedback was](https://github.com/ua-parser/uap-rust/actions/runs/23314200293/job/67810431898#step:3:1268)

> Warning: release-plz release-pr failed with HTTP 422; continuing with no PRs created.

Setting `verbose` didn't add anything useful, and it took me some time to remember that branch protection might be a factor.

Here getting the message from github would have been useful, because it would have told me release-plz hadn't managed to create *the branch*:

> Reference update failed

which is better than nothing, though worse than the message on update error (`PATCH`) which literally spells out that a protection rule was violated.

- [x] I have read the [AI Policy](https://github.com/release-plz/.github/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md).

## AI Disclosure

N/A
